### PR TITLE
fix: use correct component name for cms element

### DIFF
--- a/stubs/element/element.base.stub
+++ b/stubs/element/element.base.stub
@@ -5,7 +5,7 @@ import './preview';
 Shopware.Service('cmsService').registerCmsElement({
     name: '{{ name }}',
     label: 'sw-cms.elements.{{ label }}.label',
-    component: 'sw-cms-el-component-{{ name }}',
+    component: 'sw-cms-el-{{ name }}',
     configComponent: 'sw-cms-el-config-{{ name }}',
     previewComponent: 'sw-cms-el-preview-{{ name }}',
     defaultConfig: {


### PR DESCRIPTION
When creating a new CMS element it won't be rendered in the backend due to mismatching component names. The registerCmsElement uses `sw-cms-el-component-{{ name }}` whereas the component is named `sw-cms-el-{{ name }}`.

We want to comply with the Shopware 6 documentation and name our component `sw-cms-el-{{ name }}`.
See: https://developer.shopware.com/docs/guides/plugins/plugins/content/cms/add-cms-element