### PR TITLE
fix: use correct template filename

### DIFF
--- a/stubs/block/block.component.index.stub
+++ b/stubs/block/block.component.index.stub
@@ -1,4 +1,4 @@
-import template from './sw-cms-block-{{ name }}.html.twig';
+import template from './sw-cms-block-component-{{ name }}.html.twig';
 
 const { Component } = Shopware;
 


### PR DESCRIPTION
I think that's the last one! I don't know how I could miss it before.