### PR TITLE
 fix: use correct block template filenames

### DIFF
--- a/stubs/block/block.component.index.stub
+++ b/stubs/block/block.component.index.stub
@@ -1,4 +1,4 @@
-import template from './sw-cms-block-{{ name }}.html.twig';
+import template from './sw-cms-block-component-{{ name }}.html.twig';
 
 const { Component } = Shopware;
 

--- a/stubs/block/block.preview.index.stub
+++ b/stubs/block/block.preview.index.stub
@@ -1,5 +1,5 @@
-import template from './sw-cms-preview-{{ name }}.html.twig';
-import './sw-cms-preview-{{ name }}.scss';
+import template from './sw-cms-block-preview-{{ name }}.html.twig';
+import './sw-cms-block-preview-{{ name }}.scss';
 
 const { Component } = Shopware;
 


### PR DESCRIPTION
I think now that's the last ones! I don't know how I could miss them before.