### PR TITLE
fix: slot does not exists in component twig

### DIFF
--- a/stubs/block/block.component.twig.stub
+++ b/stubs/block/block.component.twig.stub
@@ -1,5 +1,7 @@
 {% block sw_cms_block_{{ block }} %}
 <div class="sw-cms-block-{{ name }}">
-    {{ name }}
+    <slot name="content">
+        {% block sw_cms_block_{{ block }}_slot_content %}{% endblock %}
+    </slot>
 </div>
 {% endblock %}


### PR DESCRIPTION
In case, if we have not defined `<slot>` with attribute `name` in twig file of component - have error in console + not possible to save page. This is solution for this error. 